### PR TITLE
Fixing presigning issue and clearing cache for new upload

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib import auth
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import ValidationError
+from django.core.cache import cache
 from django.shortcuts import render, redirect, reverse
 
 from main.helpers import hashstring
@@ -145,6 +145,7 @@ def upload_image(request):
         user=request.user
     )
     profile_img.save()
+    cache.delete(upload_name)
     return redirect(reverse('account'))
 
 

--- a/main/helpers.py
+++ b/main/helpers.py
@@ -40,7 +40,8 @@ def create_presigned_s3_url(bucket_key, expiration=3600,
         service_name='s3',
         aws_access_key_id=AWS_ACCESS_KEY_ID,
         aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-        config=Config(signature_version=signature_version),
+        config=Config(s3={'addressing_style': 'path'},
+                      signature_version=signature_version),
         region_name=AWS_DEFAULT_REGION,
 
     )
@@ -50,12 +51,6 @@ def create_presigned_s3_url(bucket_key, expiration=3600,
             Params={'Bucket': AWS_STORAGE_BUCKET_NAME,
                     'Key': bucket_key},
             ExpiresIn=expiration)
-        print(s3_client.list_buckets()['Owner'])
-        print(s3_client.list_objects(Bucket=AWS_STORAGE_BUCKET_NAME,
-                                     Prefix=bucket_key))
-        for key in s3_client.list_objects(Bucket=AWS_STORAGE_BUCKET_NAME,
-                                          Prefix=bucket_key)['Contents']:
-            print("Key: ", key['Key'])
     except ClientError as client_error:
         logging.error(client_error)
         return None


### PR DESCRIPTION
**Bugfixes:**
- Fixing issue `SignatureDoesNotMatch` error when presigning url for the Profile Image upload
- Deleting cache when a new Profile Image is uploaded to change the cached URL on page redirect